### PR TITLE
Fixed an issue with parsing ping6 output (missing space).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 pingparser
 ==========
-pingparser parses the output of the system ping command.
+pingparser parses the output of the system ping or ping6 command.
 
 Usage
 ~~~~~

--- a/src/pingparser.py
+++ b/src/pingparser.py
@@ -33,7 +33,7 @@ def parse(ping_output):
         `jitter`: *float*; the standard deviation between round trip ping times
                     in milliseconds
     """
-    matcher = re.compile(r'PING ([a-zA-Z0-9.\-]+) \(')
+    matcher = re.compile(r'PING ([a-zA-Z0-9.\-]+) *\(')
     host = _get_match_groups(ping_output, matcher)[0]
 
     matcher = re.compile(r'(\d+) packets transmitted, (\d+) received, (\d+)% packet loss')


### PR DESCRIPTION
For whatever reason, the outputs between `ping` and `ping6` are ever so slightly different:

```
$ ping -c 1 google.com
PING google.com (185.38.0.59) 56(84) bytes of data.
64 bytes from 185.38.0.59: icmp_seq=1 ttl=54 time=30.4 ms

--- google.com ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 30.466/30.466/30.466/0.000 ms
$ ping6 -c 1 google.com
PING google.com(lh-in-x64.1e100.net) 56 data bytes
64 bytes from lh-in-x64.1e100.net: icmp_seq=1 ttl=48 time=55.0 ms

--- google.com ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 55.090/55.090/55.090/0.000 ms
```

Note that while ping has a space between the name and the parenthesis before the address, ping6 does not. This minor patch fixes that.
