### PR TITLE
summary regex not matching

### DIFF
--- a/src/pingparser.py
+++ b/src/pingparser.py
@@ -36,7 +36,8 @@ def parse(ping_output):
     matcher = re.compile(r'PING ([a-zA-Z0-9.\-]+) *\(')
     host = _get_match_groups(ping_output, matcher)[0]
 
-    matcher = re.compile(r'(\d+) packets transmitted, (\d+) received, (\d+)% packet loss')
+    # https://regex101.com/r/zt9G2w/1
+    matcher = re.compile(r'(\d+) packets transmitted, (\d+) (?:packets )?received, (\d+)% packet loss')
     sent, received, packet_loss = _get_match_groups(ping_output, matcher)
 
     try:


### PR DESCRIPTION
Some versions of the ping binary return the summary string as:
<code>
4 packets transmitted, 4 packets received, 0% packet loss
</code>
the extra word packets before received means the regex doesn't match.

I'm not a regex expert but a perhaps a better regex on line 40 of ping parser.py might be:
<code>
(\d+) packets transmitted, (\d+) ?(packets)? received, (\d+)% packet loss
</code>